### PR TITLE
boost weapon slots to 6

### DIFF
--- a/hc/constant.hc
+++ b/hc/constant.hc
@@ -279,9 +279,11 @@ float IT_WEAPON1					= 4096;
 float IT_WEAPON2					= 1;
 float IT_WEAPON3					= 2;
 float IT_WEAPON4					= 4;
-float IT_TESTWEAP					= 8;
-float IT_WEAPON4_1					= 16;		// First half of weapon
-float IT_WEAPON4_2					= 32;		// Second half of weapon
+float IT_WEAPON5					= 8;
+float IT_WEAPON6					= 16;
+float IT_TESTWEAP					= 32;
+float IT_WEAPON4_1					= 64;		// First half of weapon
+float IT_WEAPON4_2					= 128;		// Second half of weapon
 
 
 // paladin weapons

--- a/hc/impulse.hc
+++ b/hc/impulse.hc
@@ -21,6 +21,10 @@ void restore_weapon ()
 			self.weaponmodel = "models/axe.mdl";
 		else if (self.weapon == IT_WEAPON4)
 			self.weaponmodel = "models/purifier.mdl";
+		else if (self.weapon == IT_WEAPON5)
+			self.weaponmodel = "models/gauntlet.mdl";
+		else if (self.weapon == IT_WEAPON6)
+			self.weaponmodel = "models/gauntlet.mdl";
 	}
 	else if (self.playerclass==CLASS_CRUSADER)
 	{
@@ -32,6 +36,10 @@ void restore_weapon ()
 			self.weaponmodel = "models/meteor.mdl";
 		else if (self.weapon == IT_WEAPON4)
 			self.weaponmodel = "models/sunstaff.mdl";
+		else if (self.weapon == IT_WEAPON5)
+			self.weaponmodel = "models/warhamer.mdl";
+		else if (self.weapon == IT_WEAPON6)
+			self.weaponmodel = "models/warhamer.mdl";
 	}
 	else if (self.playerclass==CLASS_NECROMANCER)
 	{
@@ -43,6 +51,10 @@ void restore_weapon ()
 			self.weaponmodel = "models/sickle.mdl";
 		else if (self.weapon == IT_WEAPON4)
 			self.weaponmodel = "models/ravenstf.mdl";
+		else if (self.weapon == IT_WEAPON5)
+			self.weaponmodel = "models/sickle.mdl";
+		else if (self.weapon == IT_WEAPON6)
+			self.weaponmodel = "models/sickle.mdl";
 	}
 	else if (self.playerclass==CLASS_ASSASSIN)
 	{
@@ -54,6 +66,10 @@ void restore_weapon ()
 			self.weaponmodel = "models/v_assgr.mdl";
 		else if (self.weapon == IT_WEAPON4)
 			self.weaponmodel = "models/scarabst.mdl";
+		else if (self.weapon == IT_WEAPON5)
+			self.weaponmodel = "models/punchdgr.mdl";
+		else if (self.weapon == IT_WEAPON6)
+			self.weaponmodel = "models/punchdgr.mdl";
 	}
 }
 
@@ -570,7 +586,7 @@ void() ImpulseCommands =
 		self.impulse=0;
 		return;
 	}
-	else if (self.impulse >= 1 && self.impulse <= 4)
+	else if (self.impulse >= 1 && self.impulse <= 6)
 		W_ChangeWeapon ();
 	else if ((self.impulse == 10) && (wp_deselect == 0))
 		CycleWeaponCommand ();

--- a/hc/newplay.hc
+++ b/hc/newplay.hc
@@ -419,8 +419,12 @@ void Pal_Change_Weapon (void)
 		self.th_missile=pal_purifier_fire;
 	else if(self.weapon==IT_WEAPON2)
 		self.th_missile=pal_vorpal_fire;
-	else
+	else if(self.weapon==IT_WEAPON3)
 		self.th_missile=pal_axe_fire;
+	else if(self.weapon==IT_WEAPON5)
+		self.th_missile=pal_gauntlet_fire;
+	else
+		self.th_missile=pal_gauntlet_fire;
 }
 
 void Cru_Change_Weapon (void)
@@ -431,8 +435,12 @@ void Cru_Change_Weapon (void)
 		self.th_missile=Cru_Ice_Fire;
 	else if(self.weapon==IT_WEAPON3)
 		self.th_missile=Cru_Met_Attack;
-	else
+	else if(self.weapon==IT_WEAPON4)
 		self.th_missile=Cru_Sun_Fire;
+	else if(self.weapon==IT_WEAPON5)
+		self.th_missile=Cru_Wham_Fire;
+	else
+		self.th_missile=Cru_Wham_Fire;
 }
 
 void Nec_Change_Weapon (void)
@@ -443,8 +451,12 @@ void Nec_Change_Weapon (void)
 		self.th_missile=setstaff_decide_attack;
 	else if(self.weapon==IT_WEAPON2)
 		self.th_missile=Nec_Mis_Attack;
-	else
+	else if(self.weapon==IT_WEAPON3)
 		self.th_missile=Nec_Bon_Attack;
+	else if(self.weapon==IT_WEAPON5)
+		self.th_missile=sickle_decide_attack;
+	else
+		self.th_missile=sickle_decide_attack;
 }
 
 void Ass_Change_Weapon (void)
@@ -455,6 +467,10 @@ void Ass_Change_Weapon (void)
 		self.th_missile=crossbow_fire;
 	if(self.weapon==IT_WEAPON3)
 		self.th_missile=grenade_throw;
+	else if(self.weapon==IT_WEAPON1)
+		self.th_missile=Ass_Pdgr_Fire;
+	else if(self.weapon==IT_WEAPON5)
+		self.th_missile=Ass_Pdgr_Fire;
 	else
 		self.th_missile=Ass_Pdgr_Fire;
 }
@@ -575,6 +591,10 @@ float weapmod, startframe,endframe,framestate;
 
 	if(self.act_state<ACT_JUMP||(self.playerclass==CLASS_NECROMANCER&&self.act_state<=ACT_JUMP))
 	{
+		if(self.weapon==IT_WEAPON6)
+			weapmod=5;
+		if(self.weapon==IT_WEAPON5)
+			weapmod=4;
 		if(self.weapon==IT_WEAPON4)
 			weapmod=3;
 		if(self.weapon==IT_WEAPON3)

--- a/hc/weapons.hc
+++ b/hc/weapons.hc
@@ -375,6 +375,32 @@ void W_SetCurrentAmmo (void)
 		else if (self.playerclass == CLASS_NECROMANCER)
 			ravenstaff_select();
 	}
+	else if (self.weapon == IT_WEAPON5)
+	{		
+		self.weaponmodel="";
+		self.weaponframe = 0;
+		if (self.playerclass == CLASS_PALADIN)
+			gauntlet_select();
+		else if (self.playerclass == CLASS_NECROMANCER)
+			sickle_select();
+		else if (self.playerclass == CLASS_CRUSADER)
+			warhammer_select();
+		else if (self.playerclass == CLASS_ASSASSIN)
+			punchdagger_select();
+	}
+	else if (self.weapon == IT_WEAPON6)
+	{		
+		self.weaponmodel="";
+		self.weaponframe = 0;
+		if (self.playerclass == CLASS_PALADIN)
+			gauntlet_select();
+		else if (self.playerclass == CLASS_NECROMANCER)
+			sickle_select();
+		else if (self.playerclass == CLASS_CRUSADER)
+			warhammer_select();
+		else if (self.playerclass == CLASS_ASSASSIN)
+			punchdagger_select();
+	}
 
 //All players will have to do this eventually, to reset
 //the stand, pain, run & fly functions for the different weapons
@@ -415,7 +441,27 @@ float W_CheckNoAmmo (float check_weapon)
 	
 	if(self.playerclass==CLASS_ASSASSIN)
 	{
-		if (check_weapon==IT_WEAPON4)
+		if (check_weapon==IT_WEAPON6)
+		{
+			if(self.artifact_active&ART_TOMEOFPOWER)
+			{
+				if(self.greenmana >= 12)
+					return TRUE;
+			}
+			else if(self.greenmana >= 3)
+					return TRUE;
+		}
+		else if (check_weapon==IT_WEAPON5)
+		{
+			if(self.artifact_active&ART_TOMEOFPOWER)
+			{
+				if(self.bluemana >= 5)
+					return TRUE;
+			}
+			else if(self.bluemana >= 2)
+				return TRUE;
+		}
+		else if (check_weapon==IT_WEAPON4)
 		{
 			if(self.artifact_active&ART_TOMEOFPOWER)
 			{
@@ -448,7 +494,27 @@ float W_CheckNoAmmo (float check_weapon)
 	}
 	else if(self.playerclass==CLASS_CRUSADER)
 	{
-		if (check_weapon==IT_WEAPON4)
+		if (check_weapon==IT_WEAPON6)
+		{
+			if(self.artifact_active&ART_TOMEOFPOWER)
+			{
+				if(self.greenmana >= 12)
+					return TRUE;
+			}
+			else if(self.greenmana >= 8)
+					return TRUE;
+		}
+		else if (check_weapon==IT_WEAPON5)
+		{
+			if(self.artifact_active&ART_TOMEOFPOWER)
+			{
+				if(self.bluemana >= 10)
+					return TRUE;
+			}
+			else if(self.bluemana >= 1)
+					return TRUE;
+		}
+		else if (check_weapon==IT_WEAPON4)
 		{
 			if(self.bluemana >= 2 && self.greenmana >= 2)
 				return TRUE;
@@ -477,7 +543,27 @@ float W_CheckNoAmmo (float check_weapon)
 	}
 	else if(self.playerclass==CLASS_NECROMANCER)
 	{
-		if (check_weapon==IT_WEAPON4)
+		if (check_weapon==IT_WEAPON6)
+		{
+			if(self.artifact_active&ART_TOMEOFPOWER)
+			{
+				if(self.greenmana >= BONE_NORMAL_COST + BONE_TOMED_COST)
+					return TRUE;
+			}
+			else if(self.greenmana >= BONE_NORMAL_COST)
+					return TRUE;
+		}
+		else if (check_weapon==IT_WEAPON5)
+		{
+			if(self.artifact_active&ART_TOMEOFPOWER)
+			{
+				if(self.bluemana >= MMIS_TOME_COST)
+					return TRUE;
+			}
+			else if(self.bluemana >= MMIS_COST)
+					return TRUE;
+		}
+		else if (check_weapon==IT_WEAPON4)
 		{
 			if(self.artifact_active&ART_TOMEOFPOWER)
 			{
@@ -510,7 +596,27 @@ float W_CheckNoAmmo (float check_weapon)
 	}
 	else if(self.playerclass==CLASS_PALADIN)
 	{
-		if (check_weapon==IT_WEAPON4)
+		if (check_weapon==IT_WEAPON6)
+		{
+			if(self.artifact_active&ART_TOMEOFPOWER)
+			{
+				if(self.greenmana >= 12)
+					return TRUE;
+			}
+			else if(self.greenmana >= 8)
+					return TRUE;
+		}
+		else if (check_weapon==IT_WEAPON5)
+		{
+			if(self.artifact_active&ART_TOMEOFPOWER)
+			{
+				if(self.bluemana >= 10)
+					return TRUE;
+			}
+			else if(self.bluemana >= 1)
+					return TRUE;
+		}
+		else if (check_weapon==IT_WEAPON4)
 		{
 			if(self.artifact_active&ART_TOMEOFPOWER)
 			{
@@ -548,8 +654,12 @@ void() W_BestWeapon =
 		self.weapon = IT_WEAPON4;
 	else if (W_CheckNoAmmo (IT_WEAPON3) && (self.items & IT_WEAPON3))
 		self.weapon = IT_WEAPON3;
+	else if (W_CheckNoAmmo (IT_WEAPON6) && (self.items & IT_WEAPON6))
+		self.weapon = IT_WEAPON6;
 	else if (W_CheckNoAmmo (IT_WEAPON2) && (self.items & IT_WEAPON2))
 		self.weapon = IT_WEAPON2;
+	else if (W_CheckNoAmmo (IT_WEAPON5) && (self.items & IT_WEAPON5))
+		self.weapon = IT_WEAPON5;
 	else self.weapon = IT_WEAPON1;
 
 /*float	test_weapon;
@@ -674,6 +784,32 @@ void W_Attack (float rightclick)
 		else if(self.playerclass==CLASS_NECROMANCER)
 			ravenstaff_fire();
 	}
+	else if (self.weapon == IT_WEAPON5)
+	{
+		if (self.playerclass==CLASS_PALADIN)
+			pal_gauntlet_fire(rightclick);
+		else if (self.playerclass==CLASS_NECROMANCER)
+			sickle_decide_attack(rightclick);
+		else if (self.playerclass==CLASS_ASSASSIN)
+		{
+			Ass_Pdgr_Fire();			
+		}
+		else if (self.playerclass==CLASS_CRUSADER)
+			Cru_Wham_Fire(rightclick);
+	}
+	else if (self.weapon == IT_WEAPON6)
+	{
+		if (self.playerclass==CLASS_PALADIN)
+			pal_gauntlet_fire(rightclick);
+		else if (self.playerclass==CLASS_NECROMANCER)
+			sickle_decide_attack(rightclick);
+		else if (self.playerclass==CLASS_ASSASSIN)
+		{
+			Ass_Pdgr_Fire();			
+		}
+		else if (self.playerclass==CLASS_CRUSADER)
+			Cru_Wham_Fire(rightclick);
+	}
 }
 
 
@@ -744,6 +880,32 @@ void W_DeselectWeapon (void)
 		else
 			W_SetCurrentAmmo();
 	}
+	else if (self.oldweapon == IT_WEAPON5)
+	{
+		if (self.playerclass==CLASS_PALADIN)
+			gauntlet_deselect();
+		else if (self.playerclass==CLASS_CRUSADER)
+			warhammer_deselect();
+		else if (self.playerclass==CLASS_ASSASSIN)
+			punchdagger_deselect();
+		else if (self.playerclass==CLASS_NECROMANCER)
+			sickle_deselect();
+		else
+			W_SetCurrentAmmo();
+	}
+	else if (self.oldweapon == IT_WEAPON6)
+	{
+		if (self.playerclass==CLASS_PALADIN)
+			gauntlet_deselect();
+		else if (self.playerclass==CLASS_CRUSADER)
+			warhammer_deselect();
+		else if (self.playerclass==CLASS_ASSASSIN)
+			punchdagger_deselect();
+		else if (self.playerclass==CLASS_NECROMANCER)
+			sickle_deselect();
+		else
+			W_SetCurrentAmmo();
+	}
 	else
 		W_SetCurrentAmmo();
 }
@@ -791,6 +953,14 @@ float	it, am, fl;
 		if ((self.bluemana < 1) && (self.greenmana <1))
 			am = 1;
 	}
+	else if (self.impulse == 5)
+	{
+		fl = IT_WEAPON5;
+	}
+	else if (self.impulse == 6)
+	{
+		fl = IT_WEAPON6;
+	}
 
 	self.impulse = 0;
 
@@ -826,7 +996,7 @@ void() CheatCommand =
 	if(deathmatch)
 		return;
 
-	self.items(+)IT_WEAPON1|IT_WEAPON2|IT_WEAPON3|IT_WEAPON4|IT_WEAPON4_1|IT_WEAPON4_2;
+	self.items(+)IT_WEAPON1|IT_WEAPON2|IT_WEAPON3|IT_WEAPON4|IT_WEAPON5|IT_WEAPON6|IT_WEAPON4_1|IT_WEAPON4_2;
 
 	self.bluemana = self.max_mana;
 	self.greenmana = self.max_mana;
@@ -870,6 +1040,14 @@ void() CycleWeaponCommand =
 			fl = IT_WEAPON4;
 		}
 		else if (fl == IT_WEAPON4)
+		{
+			fl = IT_WEAPON5;
+		}
+		else if (fl == IT_WEAPON5)
+		{
+			fl = IT_WEAPON6;
+		}
+		else if (fl == IT_WEAPON6)
 		{
 			fl = IT_WEAPON1;
 		}
@@ -919,6 +1097,14 @@ void() CycleWeaponReverseCommand =
 		else if (fl == IT_WEAPON4)
 		{
 			fl = IT_WEAPON3;
+		}
+		else if (fl == IT_WEAPON5)
+		{
+			fl = IT_WEAPON4;
+		}
+		else if (fl == IT_WEAPON6)
+		{
+			fl = IT_WEAPON5;
 		}
 		else /* ouch !!?? */
 		{
@@ -1035,6 +1221,16 @@ void ClassChangeWeapon(void)
 			self.th_weapon=purifier_select;
 			self.weaponmodel = "models/purifier.mdl";
 		}
+		else if (self.weapon == IT_WEAPON5)
+		{
+			self.th_weapon=gauntlet_select;
+			self.weaponmodel = GAUNT_TEXMOD;
+		}
+		else if (self.weapon == IT_WEAPON6)
+		{
+			self.th_weapon=gauntlet_select;
+			self.weaponmodel = GAUNT_TEXMOD;
+		}
 	}
 	else if (self.playerclass==CLASS_CRUSADER)
 	{
@@ -1057,6 +1253,16 @@ void ClassChangeWeapon(void)
 		{
 			self.th_weapon=sunstaff_select;
 			self.weaponmodel = "models/sunstaff.mdl";
+		}
+		else if (self.weapon == IT_WEAPON5)
+		{
+			self.th_weapon=warhammer_select;
+			self.weaponmodel = HAMMER_TEXMOD;
+		}
+		else if (self.weapon == IT_WEAPON6)
+		{
+			self.th_weapon=warhammer_select;
+			self.weaponmodel = HAMMER_TEXMOD;
 		}
 	}
 	else if (self.playerclass==CLASS_NECROMANCER)
@@ -1081,6 +1287,16 @@ void ClassChangeWeapon(void)
 			self.th_weapon=ravenstaff_select;
 			self.weaponmodel = "models/ravenstf.mdl";
 		}
+		else if (self.weapon == IT_WEAPON5)
+		{
+			self.th_weapon=sickle_select;
+			self.weaponmodel = SICKLE_TEXMOD;
+		}
+		else if (self.weapon == IT_WEAPON6)
+		{
+			self.th_weapon=sickle_select;
+			self.weaponmodel = SICKLE_TEXMOD;
+		}
 	}
 	else if (self.playerclass==CLASS_ASSASSIN)
 	{
@@ -1103,6 +1319,16 @@ void ClassChangeWeapon(void)
 		{
 			self.th_weapon=setstaff_select;
 			self.weaponmodel = "models/scarabst.mdl";
+		}
+		else if (self.weapon == IT_WEAPON5)
+		{
+			self.th_weapon=punchdagger_select;
+			self.weaponmodel = PDGR_TEXMOD;
+		}
+		else if (self.weapon == IT_WEAPON6)
+		{
+			self.th_weapon=punchdagger_select;
+			self.weaponmodel = PDGR_TEXMOD;
 		}
 	}
 //FIXME: take off all timed effects, lighting tinting, drawflags,


### PR DESCRIPTION
compiled and tested (some unrelated fixes required for the compile, not included)

opens up slots 5 and 6, using weapon1 for each class as placeholder