### PR TITLE
Config flags system

### DIFF
--- a/hc/allplay.hc
+++ b/hc/allplay.hc
@@ -287,8 +287,10 @@ void PlayerDead ()
 void ThrowGib (string gibname, float dm)
 {
 entity new;
+float fade;
+	fade = CheckCfgParm(PARM_FADE);
 	//ws: corpses fading can be toggled by console command (impulse 46)
-	if (corpsefading)
+	if (fade)
 		new = spawn_temp();
 	else
 		new = spawn();
@@ -303,7 +305,7 @@ entity new;
 	new.avelocity_y = random(600);
 	new.avelocity_z = random(600);
 	new.scale=random(.5,.9);
-	if (corpsefading || coop || deathmatch) {
+	if (fade || coop || deathmatch) {
 		new.think = SUB_Remove;
 		thinktime new : random(20,10);
 	}

--- a/hc/client.hc
+++ b/hc/client.hc
@@ -702,6 +702,8 @@ float pclass;
 		self.items(-)IT_WEAPON4|IT_WEAPON3|IT_WEAPON4_1|IT_WEAPON4_2|IT_WEAPON2;
 		self.skin=0;
 	}
+	else if (self.state)	//ws: config parm flags system
+		parm16 = self.state;
 //	else if(self.sv_flags)
 //		serverflags=self.sv_flags;
 
@@ -988,7 +990,7 @@ entity spot;
 	}
 
 	// Need to reset these because they could still point to entities in the previous map
-	self.enemy = self.groundentity = self.chain = self.goalentity = self.dmg_inflictor = 
+	self.enemy = self.groundentity = self.chain = self.goalentity = self.dmg_inflictor = self.ladder =
 		self.owner = world;
 
 //RESET TIMERS:
@@ -3194,3 +3196,25 @@ string deathstring, deathstring2,iclass;
 	}
 };
 
+float CheckCfgParm (float parm)	//returns value of config flag
+{
+	if (parm16&parm)
+		return TRUE;
+	else
+		return FALSE;
+}
+
+float SetCfgParm (float parm)	//toggle config flag and returns true if enabled, false if disabled
+{
+float retval;
+	if (self.state&parm) {
+		self.state=self.state-parm;
+		retval=FALSE;
+	}
+	else {
+		self.state=self.state+parm;
+		retval=TRUE;
+	}
+	parm16=self.state;
+	return retval;
+}

--- a/hc/constant.hc
+++ b/hc/constant.hc
@@ -706,3 +706,8 @@ float MAX_POLY = 1;
 float MAX_SUMMON = 1;
 float MAX_TOME = 2;
 float MAX_URN = 2;
+
+//ws: Config flags system
+float PARM_RESPAWN = 1;
+float PARM_FADE = 2;
+float PARM_BUFF = 4; 

--- a/hc/corpse.hc
+++ b/hc/corpse.hc
@@ -206,9 +206,12 @@ void corpseblink (void)
 	self.scale -= 0.10;
 
 	if (self.scale < 0.10)
-		MarkForRespawn();
-	else
-		remove(self);
+	{
+		if (CheckCfgParm(PARM_RESPAWN))
+			MarkForRespawn();
+		else
+			remove(self);
+	}
 }
 
 void init_corpseblink (void)
@@ -244,7 +247,7 @@ void () CorpseThink =
 
 	if (self.watertype==CONTENT_LAVA)	// Corpse fell in lava
 		T_Damage(self,self,self,self.health);
-	else if (corpsefading && self.lifetime < time)			// Time is up, begone with you
+	else if (CheckCfgParm(PARM_FADE) && self.lifetime < time)			// Time is up, begone with you
 		init_corpseblink();
 };
 

--- a/hc/global.hc
+++ b/hc/global.hc
@@ -76,7 +76,7 @@ entity msg_entity;
 // Set by OP_CSTATE ([++ $s..$e], [-- $s..$e]).
 float cycle_wrapped;
 
-float crouch_cnt;
+float crouch_cnt;	//unused?
 
 /*
 float modelindex_assassin;
@@ -131,7 +131,3 @@ float framecount;
 float skill;
 
 float wp_deselect;  // A flag showing a weapon is being deselected ignore impulse 10
-
-float respawning;
-float corpsefading;
-float monsterbuffing;

--- a/hc/impulse.hc
+++ b/hc/impulse.hc
@@ -586,42 +586,24 @@ void() ImpulseCommands =
 		DropInventoryItem();
 	else if (self.impulse == 45)
 	{
-		if (respawning)
-		{
-			respawning=FALSE;
-			sprint (self, "Monster respawning disabled\n");
-		}
-		else
-		{
-			respawning=TRUE;
+		if (SetCfgParm(PARM_RESPAWN))
 			sprint (self, "Monster respawning enabled\n");
-		}
+		else 
+			sprint (self, "Monster respawning disabled\n");
 	}
 	else if (self.impulse == 46)
 	{
-		if (corpsefading)
-		{
-			corpsefading=FALSE;
-			sprint (self, "Corpse fading disabled\n");
-		}
-		else
-		{
-			corpsefading=TRUE;
+		if (SetCfgParm(PARM_FADE))
 			sprint (self, "Corpse fading enabled\n");
-		}
+		else 
+			sprint (self, "Corpse fading disabled\n");
 	}
 	else if (self.impulse == 47)
 	{
-		if (monsterbuffing)
-		{
-			monsterbuffing=FALSE;
-			sprint (self, "Random monster variations disabled\n");
-		}
-		else
-		{
-			monsterbuffing=TRUE;
+		if (SetCfgParm(PARM_BUFF))
 			sprint (self, "Random monster variations enabled\n");
-		}
+		else
+			sprint (self, "Random monster variations disabled\n");
 	}
 /*	else if (self.impulse == 99)
 	{	// RJ's test impulse

--- a/hc/monsters.hc
+++ b/hc/monsters.hc
@@ -628,10 +628,8 @@ float BUFF_LEADER_CHANCE = 2; //3
 float BUFF_SPECTRE_CHANCE = 6;
 void ApplyMonsterBuff(entity monst, float canBeLeader)
 {
-	if (!monsterbuffing)
-	{
+	if (!CheckCfgParm(PARM_BUFF))
 		return;
-	}
 	
 	float randmin, randval;
 	

--- a/hc/proto.hc
+++ b/hc/proto.hc
@@ -75,4 +75,6 @@ void(entity thingy)unsheep;
 void()PlayerTouch;
 void SmallExplosion (void);
 
-
+//client.hc
+float(float parm) CheckCfgParm;	//returns value of config flag
+float(float parm) SetCfgParm;	//toggles config flag and returns true if enabled, false if disabled


### PR DESCRIPTION
Sync with configs flag system from master.
Reworked functionality of impulse 45,46,&47 (toggle monster respawning, corpse fading, & monster variants respectively). Player's choice is now tracked between levels, as they should be. Accomplished by using the player's .state field (otherwise only used by doors/plats) as a bit flag and syncing the global variable parm16 with it. Respawning and monster variants didn't even work before, now they do.