### PR TITLE
Monster raising system

### DIFF
--- a/hc/afrit.hc
+++ b/hc/afrit.hc
@@ -18,6 +18,28 @@ float AFRIT_DODGESPEED = 6;
 void() AfritCheckDodge;
 void() afrit_wake1;
 
+void afrit_raise()
+{
+float state;
+	state = RewindFrame(13,0);
+	
+	self.think = self.th_raise;
+	
+	if (state==AF_BEGINNING) {
+		sound (self, CHAN_VOICE, "afrit/death.wav", 1, ATTN_NORM);
+	}
+	if (state==AF_END) {
+		self.th_init();
+		monster_raisedebuff();
+		if (self.enemy!=world)
+			self.think=self.th_run;
+		else
+			self.think=self.th_stand;
+	}
+	
+	thinktime self : HX_FRAME_TIME;
+}
+
 void() AfritEffects
 {
 entity new;
@@ -437,6 +459,9 @@ void() monster_afrit =
 	}
 	if (!self.flags2&FL_SUMMONED && !self.flags2&FL2_RESPAWN)
 		precache_afrit();
+	
+	if (self.flags2&FL_SUMMONED || self.flags2&FL2_RESPAWN)
+		self.spawnflags(-)AFRIT_COCOON;
 
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
@@ -473,6 +498,9 @@ void() monster_afrit =
 	self.th_missile = afrit_atk1;
 	self.th_pain = afrit_pain;
 	self.th_die = afrit_die;
+	self.th_init = monster_afrit;
+	self.th_raise = afrit_raise;
+	
 	if (self.spawnflags&AFRIT_COCOON)
 		self.th_stand = afrit_sit1;
 	else	

--- a/hc/archer.hc
+++ b/hc/archer.hc
@@ -115,6 +115,28 @@ float RED_ARROW = 1;
 float GOLD_ARROW = 2;
 float BLUE_ARROW = 3;
 
+void archer_raise()
+{
+float state;
+	state = RewindFrame($deathA21,$deathA1);
+	
+	self.think = self.th_raise;
+	
+	if (state==AF_BEGINNING) {
+		sound (self, CHAN_VOICE, "archer/death.wav", 1, ATTN_NORM);
+	}
+	if (state==AF_END) {
+		self.th_init();
+		monster_raisedebuff();
+		if (self.enemy!=world)
+			self.think=self.th_run;
+		else
+			self.think=self.th_stand;
+	}
+	
+	thinktime self : HX_FRAME_TIME;
+}
+
 float archer_check_shot(void)
 {
 	vector spot1,spot2;
@@ -777,11 +799,9 @@ void monster_archer ()
 		return;
 	}
 
-	/*if(!self.th_init)
-	{
+	if(!self.th_init)
 		self.th_init=monster_archer;
-		self.init_org=self.origin;
-	}*/
+	
 	if (!self.flags2 & FL_SUMMONED&&!self.flags2&FL2_RESPAWN)
 		precache_archer();
 
@@ -803,6 +823,7 @@ void monster_archer ()
 	self.th_melee = archerdraw;
 	self.th_missile = archerdraw;
 	self.th_pain = archer_pain;
+	self.th_raise = archer_raise;
 	self.decap = 0;
 
 	if(!self.speed)
@@ -847,11 +868,9 @@ void monster_archer_lord ()
 		return;
 	}
 
-	/*if(!self.th_init)
-	{
+	if(!self.th_init)
 		self.th_init=monster_archer_lord;
-		self.init_org=self.origin;
-	}*/
+	
 	if (!self.flags2 & FL_SUMMONED&&!self.flags2&FL2_RESPAWN)
 		precache_archerlord();
 
@@ -870,6 +889,7 @@ void monster_archer_lord ()
 	self.th_melee = archerdraw;
 	self.th_missile = archerdraw;
 	self.th_pain = archer_pain;
+	self.th_raise = archer_raise;
 	self.decap = 0;
 	self.headmodel = "models/archerhd.mdl";
 	if(!self.spawnflags&ARCHER_STUCK)
@@ -905,11 +925,8 @@ Dislikes: Sunshine and happiness
 */
 void monster_archer_ice ()
 {
-	/*if(!self.th_init)
-	{
+	if(!self.th_init)
 		self.th_init=monster_archer_ice;
-		self.init_org=self.origin;
-	}*/
 	self.netname=self.classname;
 	self.classname="monster_archer";
 	monster_archer();

--- a/hc/deathknight.hc
+++ b/hc/deathknight.hc
@@ -11,30 +11,27 @@ $origin 0 0 24
 $base base
 $skin badass3
 
-/*
-
-void() blood_fall1 =[ 0, blood_fall2] {bloodpool.scale = 0;};
-void() blood_fall2 =[ 0, blood_fall3] {setmodel (bloodpool, "models/blood.mdl");bloodpool.scale = .3;};
-void() blood_fall3 =[ 0, blood_fall4] {bloodpool.scale = 0.4;};
-void() blood_fall4 =[ 0, blood_fall5] {bloodpool.scale = 0.5;};
-void() blood_fall5 =[ 0, blood_fall6] {bloodpool.scale = 0.6;};
-void() blood_fall6 =[ 0, blood_fall7] {bloodpool.scale = 0.7;};
-void() blood_fall7 =[ 0, blood_fall8] {bloodpool.scale = 0.8;};
-void() blood_fall8 =[ 0, blood_fall8] {bloodpool.scale = 1.0;bloodpool.think = SUB_Remove; bloodpool.nextthink = time + 15;};
-
-void() blood_fx =
-{	
-	bloodpool = spawn ();
-	bloodpool.owner = self;
-	bloodpool.movetype = MOVETYPE_BOUNCE;
-	bloodpool.origin = self.origin + '0 0 0';
-	setsize (bloodpool, '0 5 1', '5 5 5');
-	bloodpool.think = blood_fall1;
-	bloodpool.nextthink = time + 0.01;
+void death_knight_raise()
+{
+float state;
+	state = RewindFrame(89,69);
 	
+	self.think = self.th_raise;
+	
+	if (state==AF_BEGINNING) {
+		sound (self, CHAN_VOICE, "death_knight/kdeath.wav", 1, ATTN_NORM);
+	}
+	if (state==AF_END) {
+		self.th_init();
+		monster_raisedebuff();
+		if (self.enemy!=world)
+			self.think=self.th_run;
+		else
+			self.think=self.th_stand;
+	}
+	
+	thinktime self : HX_FRAME_TIME;
 }
-
-*/
 
 void()	death_knight_stand1	=[	0,	death_knight_stand2	] {ai_stand();};
 void()	death_knight_stand2	=[	1,	death_knight_stand3	] {ai_stand();};
@@ -273,6 +270,9 @@ void() monster_death_knight =
 	self.th_melee = death_knight_atk1;
 	self.th_pain = death_knight_pain;
 	self.th_die = death_knight_die;
+	self.th_raise = death_knight_raise;
+	self.th_init = monster_death_knight;
 	
+	self.buff=1;
 	walkmonster_start ();
 };

--- a/hc/imp.hc
+++ b/hc/imp.hc
@@ -137,6 +137,28 @@ float imp_fly_amounts[20] =
 	-0.4
 };
 
+void imp_raise()
+{
+float state;
+	state = RewindFrame($death14,$death1);
+	
+	self.think = self.th_raise;
+	
+	if (state==AF_BEGINNING) {
+		sound (self, CHAN_VOICE, "imp/die.wav", 1, ATTN_NORM);
+	}
+	if (state==AF_END) {
+		self.th_init();
+		monster_raisedebuff();
+		if (self.enemy!=world)
+			self.think=self.th_run;
+		else
+			self.think=self.th_stand;
+	}
+	
+	thinktime self : HX_FRAME_TIME;
+}
+
 void imp_drop (void)
 {
 	self.attack_state=AS_STRAIGHT;
@@ -1586,6 +1608,7 @@ void init_imp (float which_skin)
 		self.th_pain = imp_pain;
 		self.th_missile = imp_enter_swoop;
 		self.th_melee = imp_attack;
+		self.th_raise=imp_raise;
 	}
 
 	self.yaw_speed=8;
@@ -1619,10 +1642,8 @@ void init_imp (float which_skin)
 	else
 	{
 		self.flags (+) FL_MONSTER | FL_FLY;
-	}
-	
-	if (self.classname!="gargoyle")
 		self.buff=1;
+	}
 	
 	if(self.enemy)
 		self.th_run();
@@ -1644,6 +1665,8 @@ wait = if you give it a -1, the gargoyle will not come alive, it's just a decora
 */
 void monster_imp_ice ()
 {
+	if(!self.th_init)
+		self.th_init=monster_imp_ice;
 	init_imp(1);
 }
 
@@ -1658,6 +1681,8 @@ wait = if you give it a -1, the gargoyle will not come alive, it's just a decora
 */
 void monster_imp_fire ()
 {
+	if(!self.th_init)
+		self.th_init=monster_imp_fire;
 	init_imp(0);
 }
 

--- a/hc/medusa.hc
+++ b/hc/medusa.hc
@@ -158,6 +158,28 @@ void()medusa_attack_left;
 void()medusa_attack;
 void(float action)MedusaSelectDir;
 
+void medusa_raise()
+{
+float state;
+	state = RewindFrame($death20,$death01);
+	
+	self.think = self.th_raise;
+	
+	if (state==AF_BEGINNING) {
+		sound (self, CHAN_VOICE, "medusa/death.wav", 1, ATTN_NORM);
+	}
+	if (state==AF_END) {
+		self.th_init();
+		monster_raisedebuff();
+		if (self.enemy!=world)
+			self.think=self.th_run;
+		else
+			self.think=self.th_stand;
+	}
+	
+	thinktime self : HX_FRAME_TIME;
+}
+
 void medusa_check_use_model (string modelstring)
 {
 	if(self.model!=modelstring)
@@ -548,8 +570,10 @@ void MedusaHeadDying () [++ 46 .. 105]
 		else if(self.frame==105)
 		{
 			self.skin=1;
-			self.think=init_corpseblink;
-			thinktime self : 5;
+			self.preventrespawn=TRUE;
+			self.think=CorpseThink;
+			/*self.think=init_corpseblink;
+			thinktime self : 5;*/
 		}
 }
 
@@ -948,6 +972,8 @@ void monster_medusa_green (void)
 	self.th_pain=medusa_pain;
 	self.th_missile=medusa_rattle;
 	self.th_melee=medusa_attack;
+	self.th_init=monster_medusa_green;
+	self.th_raise=medusa_raise;
 
 	setmodel (self, "models/medusa.mdl");
 

--- a/hc/monsters.hc
+++ b/hc/monsters.hc
@@ -606,3 +606,42 @@ void monster_jump ()	//ws: generic think function for monsters in the air due to
 		thinktime self : 0.01;
 	}
 }
+
+void monster_raisedebuff()
+{	//called by risen monsters after initializing their default values but before entering their think states
+	self.buff = 0;		//dont turn into a buffed monster variant
+	self.health *= 0.75;
+	self.experience_value *= 0.75;
+}
+
+void monster_raiseinit(entity corpse)
+{
+	if (!corpse.th_raise || !corpse.th_init)
+		return;
+	
+entity new;		//create new entity to avoid inheriting anything weird from corpse
+	new = spawn();
+	setsize (new, corpse.mins, corpse.maxs);
+	setmodel(new, corpse.model);
+	setorigin(new, corpse.origin);
+	
+	new.frame = corpse.frame;
+	new.scale = corpse.scale;
+	new.drawflags = corpse.drawflags;
+	new.skin = corpse.skin;
+	new.flags2 (+) FL2_RESPAWN;		//dont precache
+	new.enemy = corpse.enemy;
+	new.classname = corpse.classname;
+	new.th_init = corpse.th_init;
+	new.th_raise = corpse.th_raise;
+	new.think = new.th_raise;
+	thinktime new : 0;
+	
+	remove(corpse);
+	/*corpse.buff = 0;					//dont apply monster variation
+	corpse.flags2 (+) FL_SUMMONED;		//dont precache
+	corpse.health = corpse.max_health*0.75;
+	corpse.think = corpse.th_raise;
+	thinktime corpse : 0;*/
+}
+

--- a/hc/scorpion.hc
+++ b/hc/scorpion.hc
@@ -104,6 +104,28 @@ float ScorpionStandFrames[6] =
 
 // CODE --------------------------------------------------------------------
 
+void scorpion_raise()
+{
+float state;
+	state = RewindFrame($SCDead21,$SCDead21);
+	
+	self.think = self.th_raise;
+	
+	if (state==AF_BEGINNING) {
+		sound (self, CHAN_VOICE, "scorpion/death.wav", 1, ATTN_NORM);
+	}
+	if (state==AF_END) {
+		self.th_init();
+		monster_raisedebuff();
+		if (self.enemy!=world)
+			self.think=self.th_run;
+		else
+			self.think=self.th_stand;
+	}
+	
+	thinktime self : HX_FRAME_TIME;
+}
+
 //==========================================================================
 //
 // monster_scorpion_yellow
@@ -120,6 +142,8 @@ AMBUSH
 
 void monster_scorpion_yellow(void)
 {
+	if(!self.th_init)
+		self.th_init=monster_scorpion_yellow;
 	ScorpionInit(SCORPION_YELLOW);
 }
 
@@ -139,6 +163,8 @@ AMBUSH
 
 void monster_scorpion_black(void)
 {
+	if(!self.th_init)
+		self.th_init=monster_scorpion_black;
 	ScorpionInit(SCORPION_BLACK);
 }
 
@@ -202,6 +228,7 @@ void ScorpionInit(float type)
 	self.th_melee = ScorpionMeleeDecide;
 	self.th_pain = ScorpionPainDecide;
 	self.th_die = ScorpionDieInit;
+	self.th_raise = scorpion_raise;
 
 	self.view_ofs = '0 0 12';
 

--- a/hc/skullwiz.hc
+++ b/hc/skullwiz.hc
@@ -83,8 +83,63 @@ void skullwiz_blink(void);
 void skullwiz_push (void);
 void skullwiz_missile_init (void);
 
+void monster_raiseinit (entity corpse);
+
 float SKULLBOOK  =0;
 float SKULLHEAD  =1;
+
+entity skullwiz_findcorpse ()
+{
+entity corpse;
+	corpse = findradius(self.origin, 288);
+	while(corpse)
+	{
+		if (corpse.th_raise && !corpse.decap && corpse.th_init && corpse.think == CorpseThink && !corpse.preventrespawn) {
+			return corpse;
+		}
+		corpse = corpse.chain;
+	}
+	return world;
+}
+
+void skullwiz_raise(void)
+{
+entity risen;
+	risen = skullwiz_findcorpse();
+	if (risen==world)
+		return;
+		
+	risen.enemy = self.enemy;
+	risen.controller = self;
+	monster_raiseinit(risen);
+}
+
+void skullwiz_raiseinit (void) [++ $skgate1..$skgate30]
+{
+	self.think = skullwiz_raiseinit;
+	
+	if (self.frame == $skgate2) {	dprint("ring\n");
+		entity ring;
+		ring = spawn();
+		setorigin (ring, self.origin);
+		ring.owner = self;
+		ring.lifetime = time + .8;
+		setmodel(ring, "models/proj_ringshock.mdl");
+		ring.think = shockwave;
+		thinktime ring : .1;
+		
+		sound (ring, CHAN_BODY, "skullwiz/gate.wav", 1, ATTN_NORM);
+	}
+
+	if (self.frame >= $skgate10 && self.frame <= $skgate23) {	dprint("raisin");
+		skullwiz_raise();
+	}
+
+	if (cycle_wrapped) {
+		self.glyph_finished=time+5;		//dont raise corpses again until this timer is up
+		skullwiz_run();
+	}
+}
 
 float() SkullFacingIdeal =
 {
@@ -303,7 +358,6 @@ void spider_grow(void)
 		walkmonster_start();
 }
 
-
 void skullwiz_summon(void)
 {
 	vector newangle,spot1,spot2,spot3;
@@ -326,8 +380,8 @@ void skullwiz_summon(void)
 	self.lifetime = time + 30;
 
 	self.skin = 1;
-	self.health = 5;
-	self.experience_value = SpiderExp[1];
+	self.health = self.max_health = 5;
+	self.init_exp_val = self.experience_value = SpiderExp[1];
 
 	self.drawflags = SCALE_ORIGIN_BOTTOM;
 	self.spawnflags (+) JUMP;
@@ -346,8 +400,6 @@ void skullwiz_summon(void)
 	self.th_melee = SpiderMeleeBegin;
 	self.th_missile = SpiderJumpBegin;
 	self.th_pain = SpiderPain;
-	/*self.th_possum = spider_playdead;
-	self.th_possum_up = spider_possum_up;*/
 	self.classname = "monster_spider_yellow_small";
 
 	self.flags (+) FL_MONSTER;
@@ -413,7 +465,7 @@ void skullwiz_summon(void)
 
 void skullwiz_summoninit (void) [++ $skgate1..$skgate30]
 {
-
+	thinktime self : HX_FRAME_TIME*0.5;	//ws: speed up animation
 	if (self.frame == $skgate2)   // Gate in the creatures
 		sound (self, CHAN_VOICE, "skullwiz/gatespk.wav", 1, ATTN_NORM);
 
@@ -421,7 +473,7 @@ void skullwiz_summoninit (void) [++ $skgate1..$skgate30]
 	{
 		spider_spawn(0);
 
-		if (random() < 0.15 || self.bufftype & BUFFTYPE_LEADER)   // 15% chance he'll do another
+		if (random() < 0.15 || coop || self.bufftype & BUFFTYPE_LEADER)   // 15% chance he'll do another
 		{
 			spider_spawn(1);
 		}
@@ -560,9 +612,7 @@ void SkullMissile_Twist(void)
 	}
 	
 	if (self.owner.bufftype & BUFFTYPE_LEADER)
-	{
 		HomeThink();
-	}
 }
 
 /*-----------------------------------------
@@ -682,7 +732,9 @@ void skullwiz_missile (void) [++ $skspel2..$skspel30]
   -----------------------------------------*/
 void skullwiz_missile_init (void) [++ $skredi1..$skredi12]
 {
-
+	if (self.classname=="monster_skull_wizard_lord" && self.frame<=$skredi2 && skullwiz_findcorpse()!=world)
+		skullwiz_raiseinit();
+	
 	self.frame += 2;
 
 	if (cycle_wrapped)
@@ -721,7 +773,8 @@ void skullwiz_blinkin(void)
 		//restore monster effects
 		ApplyMonsterBuffEffect(self);
 		
-		self.counter = time+1;	//ws: dont teleport again immediately, give player a little time to retaliate
+		self.counter = time+1;			//ws: dont teleport again immediately, give player a little time to retaliate
+		self.glyph_finished = time+1;	//also dont immediately revive corpses
 		
 		skullwiz_run();
 	}
@@ -779,13 +832,20 @@ float loop_cnt,forward,dot;
 		else
 			spot1 = self.origin;
 
-		forward = random(120,200);
-		spot2 = spot1 + (v_forward * forward);
-		traceline (spot1, spot2 + (v_forward * 30) , FALSE, self.enemy);
+		//forward = random(120,200);
+		//spot2 = spot1 + (v_forward * forward);
+		//traceline (spot1, spot2 + (v_forward * 30) , FALSE, self.enemy);
+		forward = random((self.size_x + self.size_y),200.00000);
+		spot2 = (spot1 + (v_forward * forward) + (v_up * forward));
+		traceline ( spot1, (spot2 + (v_forward * ((self.size_x + self.size_y) * 0.5))), TRUE, self.enemy);
 		if (trace_fraction == 1.0) //  Check no one is standing where monster wants to be
 		{
+			traceline ( spot2, (spot2 - (v_up * (forward * 2.00000))), TRUE, self.enemy);
+			spot2 = trace_endpos;
+			
    			makevectors (newangle);
-			tracearea (spot2,spot2 + v_up * 80,'-32 -32 -10','32 32 46',FALSE,self);
+			//tracearea (spot2,spot2 + v_up * 80,'-32 -32 -10','32 32 46',FALSE,self);
+			tracearea ( spot2, (spot2 + (v_up * 80.00000)), self.mins, self.maxs, FALSE, self.enemy);
 			if ((trace_fraction == 1.0) && (!trace_allsolid)) // Check there is a floor at the new spot
 			{
 				spot3 = spot2 + (v_up * -4);
@@ -894,7 +954,6 @@ void skullwiz_blink(void) [++ $sktele2..$sktele30]
 		self.aflag=FALSE;
 		self.takedamage = DAMAGE_NO;  // So t_damage won't force him into another state 
 		self.scale = 1;
-		
 		if (self.bufftype & BUFFTYPE_LARGE)
 			self.scale = self.tempscale;
 		
@@ -967,7 +1026,7 @@ void skullwiz_melee (void) [++ $skspel2..$skspel30]
 		}
 		else  // Only the skull wizard lord can summon
 		{
-			if (random()< 0.15)
+			if (random()< 0.25)		//vanilla: 0.15
 				skullwiz_summoninit();
 			else
 			{
@@ -1010,6 +1069,12 @@ void skullwiz_run (void) [++ $skwalk1..$skwalk24]
 			sound (self, CHAN_VOICE, "skullwiz/growl.wav", 1, ATTN_NORM);
 		else
 			sound (self, CHAN_VOICE, "skullwiz/growl2.wav", 1, ATTN_NORM);
+	}
+	
+	if (self.classname=="monster_skull_wizard_lord" && time>self.glyph_finished)
+	{	//ws: lord wizards can revive dead bodies
+		if (skullwiz_findcorpse()!=world)
+			skullwiz_raiseinit();
 	}
 
 	delta = self.enemy.origin - self.origin;
@@ -1073,7 +1138,6 @@ void skullwizard_init(void)
 		precache_model("models/skulbook.mdl");
 		precache_model("models/skulhead.mdl");
 		precache_model("models/skulshot.mdl");
-		precache_model("models/spider.mdl");
 
 		if (self.classname == "monster_skull_wizard")
 		{
@@ -1082,7 +1146,6 @@ void skullwizard_init(void)
 			precache_sound("skullwiz/growl.wav");
 			precache_sound("skullwiz/scream.wav");
 			precache_sound("skullwiz/pain.wav");
-//	precache_sound("spider/death.wav");
 		}	
 		else
 		{
@@ -1100,8 +1163,7 @@ void skullwizard_init(void)
 		precache_sound("skullwiz/push.wav");
 		precache_sound("skullwiz/firemisl.wav");
 
-		precache_spider ();
-
+		precache_spider();
 	}
 
 	setmodel(self, "models/skullwiz.mdl");
@@ -1148,6 +1210,7 @@ void monster_skull_wizard (void)
 	self.health = 150;
 	self.experience_value = 100;
 	self.monsterclass = CLASS_GRUNT;
+	self.th_init = monster_skull_wizard;
 	
 	self.buff=2;
 	walkmonster_start();
@@ -1169,12 +1232,14 @@ void monster_skull_wizard_lord (void)
 
 	skullwizard_init();
 
-	self.health = 600;
-	self.experience_value = 400;
+	self.health = 600;				//vanilla: 650
+	self.experience_value = 300;	//vanilla: 325
 	self.monsterclass = CLASS_LEADER;
 	self.skin = 1;
 	self.scale = 1.20;
+	self.th_init = monster_skull_wizard_lord;
 	
 	self.buff=1;
 	walkmonster_start();
 }
+

--- a/hc/spider.hc
+++ b/hc/spider.hc
@@ -99,6 +99,28 @@ float SpiderExp[4] =
 
 // CODE --------------------------------------------------------------------
 
+void spider_raise()
+{
+float state;
+	state = RewindFrame($sdeath20,$sdeath1);
+	
+	self.think = self.th_raise;
+	
+	if (state==AF_BEGINNING) {
+		sound (self, CHAN_VOICE, "spider/death.wav", 1, ATTN_NORM);
+	}
+	if (state==AF_END) {
+		self.th_init();
+		monster_raisedebuff();
+		if (self.enemy!=world)
+			self.think=self.th_run;
+		else
+			self.think=self.th_stand;
+	}
+	
+	thinktime self : HX_FRAME_TIME;
+}
+
 void monster_spider(void) {}
 
 //==========================================================================
@@ -120,6 +142,8 @@ IMPORTANT!  Put ONWALL spiders 8 pixels away from the wall you want them to be o
 
 void monster_spider_red_large(void)
 {
+	if(!self.th_init)
+		self.th_init=monster_spider_red_large;
 	SpiderInit(SPIDER_RED_LARGE);
 }
 
@@ -142,6 +166,8 @@ IMPORTANT!  Put ONWALL spiders 8 pixels away from the wall you want them to be o
 
 void monster_spider_red_small(void)
 {
+	if(!self.th_init)
+		self.th_init=monster_spider_red_small;
 	SpiderInit(SPIDER_RED_SMALL);
 }
 
@@ -164,6 +190,8 @@ IMPORTANT!  Put ONWALL spiders 8 pixels away from the wall you want them to be o
 
 void monster_spider_yellow_large(void)
 {
+	if(!self.th_init)
+		self.th_init=monster_spider_yellow_large;
 	SpiderInit(SPIDER_YELLOW_LARGE);
 }
 
@@ -185,6 +213,8 @@ IMPORTANT!  Put ONWALL spiders 8 pixels away from the wall you want them to be o
 
 void monster_spider_yellow_small(void)
 {
+	if(!self.th_init)
+		self.th_init=monster_spider_yellow_small;
 	SpiderInit(SPIDER_YELLOW_SMALL);
 }
 


### PR DESCRIPTION
Skull wizard lord monster can resurrect nearby corpses; this spawns new monster that inherits various properties from the corpse, plays the monster's death animation in reverse, and starts alerted.