### PR TITLE
set init_exp_val with all monsters due to portals dmg exp award

### DIFF
--- a/hc/afrit.hc
+++ b/hc/afrit.hc
@@ -521,6 +521,7 @@ void() monster_afrit =
 	if(!self.mass)
 		self.mass = 6;
 	
+	self.init_exp_val = self.experience_value;
 	self.headmodel = "models/h_imp.mdl";
 	
 	self.th_walk = afrit_glide1;

--- a/hc/bishop.hc
+++ b/hc/bishop.hc
@@ -383,6 +383,8 @@ void() monster_bishop =
 	if(!self.mass)
 		self.mass = 10;
 
+	self.init_exp_val = self.experience_value;
+
 	self.th_stand = dark_bishop_float1;
 	self.th_walk = dark_bishop_walk1;
 	self.th_run = dark_bishop_run1;

--- a/hc/deathknight.hc
+++ b/hc/deathknight.hc
@@ -232,6 +232,8 @@ void() monster_death_knight =
 	if(!self.experience_value)
 		self.experience_value = 15;
 	
+	self.init_exp_val = self.experience_value;
+	
 	if(!self.mass)
 		self.mass = 11;
 		

--- a/hc/disciple.hc
+++ b/hc/disciple.hc
@@ -312,6 +312,8 @@ void() monster_disciple =
 	if(!self.mass)
 		self.mass = 15;		//self.mass = 80;
 
+	self.init_exp_val = self.experience_value;
+	
 	self.th_stand = bishop_float1;
 	self.th_walk = bishop_walk1;
 	self.th_run = bishop_run1;

--- a/hc/reiver.hc
+++ b/hc/reiver.hc
@@ -528,6 +528,8 @@ void monster_reiver ()
 	self.aflag = 0;	//counter for draining health
 	self.count = time+2;	//counter for look anim
 	self.experience_value = 40;
+	self.init_exp_val = self.experience_value;
+
 	self.flags (+) FL_FLY;
 	if (!self.health)
 		self.health = 120;


### PR DESCRIPTION
oldmission awards exp on killed(), portals on damage (subtracts from ent.experience_value so it's near 0 when the monster expires.)