### PR TITLE
Add fields for raw strings

### DIFF
--- a/hc/buttons.hc
+++ b/hc/buttons.hc
@@ -52,9 +52,12 @@ void() button_fire =
 
 	if (self.inactive)
 	{
-		if (other.classname == "player" && self.msg2) 
+		if (other.classname == "player" && (self.msg2 || self.msg2str!="")) 
 		{
-			s = getstring(self.msg2);
+			if (self.msg2str!="")			//SoC: triggers can use msg2str for raw string instead of using an index for strings.txt
+				s = self.msg2str;
+			else
+				s = getstring(self.msg2);
 			centerprint(other, s);
 		}
 		return;	

--- a/hc/doors.hc
+++ b/hc/doors.hc
@@ -25,8 +25,6 @@ Door.enemy chains from the master door through all doors linked in the chain.
 void door_hit_bottom();
 void door_hit_top();
 
-
-
 /*
 ===========================================================================
 door_slide
@@ -377,6 +375,7 @@ void door_fire()
 		objerror ("door_fire: self.owner != self");
 
 	self.no_puzzle_msg = 0;
+	self.no_puzzle_str = "";	//SoC
 
 // play use key sound
 
@@ -471,9 +470,12 @@ void door_trigger_touch()
 
 		if (!check_puzzle_pieces(other,removepp,inversepp))
 		{
-			if (self.no_puzzle_msg && !deathmatch) 
+			if ((self.no_puzzle_msg || self.no_puzzle_str!="") && !deathmatch) 
 			{
-				temp = getstring(self.no_puzzle_msg);
+				if (self.no_puzzle_str!="")
+					temp = self.no_puzzle_str;
+				else
+					temp = getstring(self.no_puzzle_msg);
 				centerprint (other, temp);
 				door.attack_finished = time + 2;
 			}
@@ -528,15 +530,18 @@ void door_touch()
 		else
 			T_Damage (other, self, self, other.health+50);
 	}
-
+	
 	if(self.owner.attack_finished > time)
 		return;
 
 	self.owner.attack_finished = time + 2;
 
-	if(self.owner.message != 0 && other.flags&FL_CLIENT && !deathmatch)
+	if((self.owner.message || self.owner.messagestr!="") && other.flags&FL_CLIENT && !deathmatch)
 	{
-		temp = getstring(self.owner.message);
+		if (self.owner.messagestr != "")			//SoC: triggers can use messagestr for raw string instead of using an index for strings.txt
+			temp = self.owner.messagestr;
+		else
+			temp = getstring(self.owner.message);
 		centerprint (other, temp);
 		sound (other, CHAN_VOICE, "misc/comm.wav", 1, ATTN_NORM);
 	}
@@ -553,9 +558,12 @@ void door_touch()
 
 	if (!check_puzzle_pieces(other,removepp,inversepp))
 	{
-		if (self.no_puzzle_msg && !deathmatch)
+		if ((self.no_puzzle_msg || self.no_puzzle_str!="") && !deathmatch)
 		{
-			temp = getstring(self.no_puzzle_msg);
+			if (self.no_puzzle_str!="")
+				temp = self.no_puzzle_str;
+			else
+				temp = getstring(self.no_puzzle_msg);
 			centerprint (other, temp);
 		}
 		return;
@@ -836,7 +844,7 @@ void door_sounds(void)
 		self.noise2 = "doors/penswing.wav";
 		self.noise4 = "doors/penstart.wav";
 	}
-	else if (self.soundtype == 10)	// Pully
+	else if (self.soundtype == 10)	// Pully plat
 	{
 		precache_sound ("plats/pulyplt1.wav");
 		precache_sound ("plats/pulyplt2.wav");
@@ -845,7 +853,7 @@ void door_sounds(void)
 		self.noise2 = "plats/pulyplt1.wav";
 		self.noise4 = "plats/pulyplt1.wav";
 	}
-	else if (self.soundtype == 11)	// Chain
+	else if (self.soundtype == 11)	// Chain plat
 	{
 		precache_sound ("plats/chainplt1.wav");
 		precache_sound ("plats/chainplt2.wav");
@@ -863,6 +871,15 @@ void door_sounds(void)
 		self.noise1 = "fx/boldstop.wav";
 		self.noise2 = "doors/penswing.wav";
 		self.noise4 = "misc/null.wav";
+	}
+	else if (self.soundtype == 13)	// Stone plat
+	{
+		precache_sound ("plats/platslid.wav");
+		precache_sound ("plats/platstp.wav");
+		
+		self.noise1 = "plats/platstp.wav";
+		self.noise2 = "plats/platslid.wav";
+		self.noise4 = "plats/platslid.wav";
 	}
 }
 
@@ -1336,9 +1353,12 @@ void secret_touch()
 
 	self.attack_finished = time + 2;
 	
-	if (self.message)
+	if (self.message || self.messagestr!="")
 	{
-		s = getstring(self.message);
+		if (self.messagestr != "")			//SoC: triggers can use messagestr for raw string instead of using an index for strings.txt
+			s = self.messagestr;
+		else
+			s = getstring(self.message);
 		centerprint (other, s);
 		sound (other, CHAN_BODY, "misc/comm.wav", 1, ATTN_NORM);
 	}

--- a/hc/subs.hc
+++ b/hc/subs.hc
@@ -3,7 +3,7 @@
  */
 
 float SPAWNFLAG_ACTIVATED	= 8;
-
+float SPAWNFLAG_USESTRING = 131072;
 
 void SUB_Null() {}
 
@@ -77,8 +77,8 @@ void InitTrigger()
 
 void(vector tdest, float tspeed, void() func) SUB_CalcMove =
 {
-	local vector vdestdelta;
-	local float  len, traveltime;
+vector vdestdelta;
+float  len, traveltime;
 
 	if(!tspeed)
 		objerror("No speed is defined!");
@@ -395,6 +395,7 @@ string s;
 		t.think = DelayThink;
 		t.enemy = activator;
 		t.message = self.message;
+		t.messagestr = self.messagestr;
 		t.killtarget = self.killtarget;
 		t.target = self.target;
 		return;
@@ -403,9 +404,12 @@ string s;
 //
 // print the message
 //
-	if(activator.classname == "player" && self.message != 0)
+	if(activator.flags&FL_CLIENT && (self.message || self.messagestr != ""))
 	{
-		s = getstring(self.message);
+		if (self.messagestr != "")			//SoC: triggers can use messagestr for raw string instead of using an index for strings.txt
+			s = self.messagestr;
+		else
+			s = getstring(self.message);
 		centerprint (activator, s);
 		if(!self.noise)
 			sound (activator, CHAN_VOICE, "misc/comm.wav", 1, ATTN_NORM);
@@ -514,7 +518,7 @@ void (void() thinkst) SUB_CheckRefire =
 };
 */
 
-void SUB_UseWakeTargets()
+void SUB_UseWakeTargets()	//ws: monsters use self.waketarget upon sighting player
 {
 	if (self.waketarget=="")
 		return;

--- a/hc/triggers.hc
+++ b/hc/triggers.hc
@@ -73,7 +73,7 @@ void() multi_trigger =
 
 	if (self.experience_value && activator.flags&FL_CLIENT)
 	{
-		AwardExperience(activator,self,self.experience_value);	//ws: changes to self.experience_value from 0 (?)
+		AwardExperience(activator,self,self.experience_value);	//ws: changed to self.experience_value from 0 (?)
 	}
 
 	self.check_ok=TRUE;
@@ -213,9 +213,12 @@ void() multi_use =
 
 	if (!check_puzzle_pieces(other,removepp,inversepp))
 	{
-		if (self.no_puzzle_msg && !deathmatch)
+		if ((self.no_puzzle_msg || self.no_puzzle_str!="") && !deathmatch)
 		{
-			temp = getstring(self.no_puzzle_msg);
+			if (self.no_puzzle_str!="")
+				temp = self.no_puzzle_str;
+			else
+				temp = getstring(self.no_puzzle_msg);
 			if (!deathmatch)
 				centerprint (other, temp);
 			self.attack_finished = time + 2;
@@ -270,9 +273,12 @@ void() multi_touch =
 
 	if (!check_puzzle_pieces(other,removepp,inversepp))
 	{
-		if (self.no_puzzle_msg && !deathmatch)
+		if ((self.no_puzzle_msg || self.no_puzzle_str!="") && !deathmatch)
 		{
-			temp = getstring(self.no_puzzle_msg);
+			if (self.no_puzzle_str!="")
+				temp = self.no_puzzle_str;
+			else
+				temp = getstring(self.no_puzzle_msg);
 			if (!deathmatch)
 				centerprint (other, temp);
 			self.attack_finished = time + 2;
@@ -425,6 +431,11 @@ void () interval_use =
 //	dprint("interval used\n");
 
 	self.think = interval_use;
+	if (self.count) {
+		++self.counter;
+		if (self.counter > self.count)
+			self.think = SUB_Remove;
+	}
 	thinktime self : self.wait;
 };
 
@@ -438,9 +449,9 @@ void() trigger_interval =
 	InitTrigger ();
 
 	self.use = interval_use;
-
+	
 	self.think = interval_use;
-	if (!self.targetname)
+	if (!self.targetname && !self.targetid)
 		thinktime self : 0.1;
 };
 
@@ -588,8 +599,13 @@ string temp;
 			if (activator.classname == "player" && (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0 &&
 			    !deathmatch)
 			{
-				if(self.message)
-					temp=getstring(self.message);
+				if(self.message || self.messagestr!="")
+				{
+					if (self.messagestr!="")			//SoC: triggers can use messagestr for raw string instead of using an index for strings.txt
+						temp=self.messagestr;
+					else
+						temp=getstring(self.message);
+				}
 				else
 					temp="Sequence completed!";
 				centerprint(activator, temp);
@@ -608,8 +624,13 @@ string temp;
 			self.check_ok = FALSE;
 			if (activator.classname == "player" && !deathmatch) 
 			{
-				if (self.msg2) 
-					temp = getstring(self.msg2);
+				if (self.msg2 || self.msg2str!="")
+				{
+					if (self.msg2str!="")			//SoC: triggers can use msg2str for raw string instead of using an index for strings.txt
+						temp = self.msg2str;
+					else
+						temp = getstring(self.msg2);
+				}
 				else
 					temp = "Nothing seemed to happen";
 				centerprint(activator, temp);
@@ -1393,7 +1414,10 @@ void() trigger_hurt =
 	}
 	if (!self.dmg)
 		self.dmg = 1000;
+	if(!self.wait)
+		self.wait = 1;
 };
+
 //============================================================================
 
 //============================================================================
@@ -2108,8 +2132,11 @@ FEILDS
 void trigger_message_transfer_use ()
 {
 	string temp;
-
-	temp = getstring(self.message);
+	
+	if (self.messagestr != "")			//SoC: triggers can use messagestr for raw string instead of using an index for strings.txt
+		temp = self.messagestr;
+	else
+		temp = getstring(self.message);
 	if (!deathmatch)
 		centerprint(activator, temp);
 	other.nexttarget=self.target;


### PR DESCRIPTION
Add .messagestr, .msg2str, and .no_puzzle_str fields. Instead of using an index to a string in strings.txt, these fields take whatever string a mapper uses in the map.