### PR TITLE
Add fields for raw strings

### DIFF
--- a/hc/buttons.hc
+++ b/hc/buttons.hc
@@ -53,12 +53,15 @@ void() button_fire =
 
 	if (self.inactive)
 	{
-		if (other.classname == "player" && self.msg2) 
+		if (other.classname == "player" && (self.msg2 || self.msg2str!="")) 
 		{
-			s = getstring(self.msg2);
+			if (self.msg2str!="")			//SoC: triggers can use msg2str for raw string instead of using an index for strings.txt
+				s = self.msg2str;
+			else
+				s = getstring(self.msg2);
 			centerprint(other, s);
 		}
-		return;	
+		return;
 	}
 
 	if(self.spawnflags&BUTTON_TOGGLE&&self.state==STATE_TOP)

--- a/hc/doors.hc
+++ b/hc/doors.hc
@@ -501,11 +501,17 @@ entity	starte;
 	if (self.owner != self)
 		objerror ("door_fire: self.owner != self");
 
-	self.no_puzzle_msg = 0;
+	if (self.no_puzzle_msg)
+		self.no_puzzle_msg = 0;
+	if (self.no_puzzle_str!="")
+		self.no_puzzle_str = "";	//SoC
 
 // play use key sound
 
-	self.message = 0;		// no more message
+	if (self.message)
+		self.message = 0;		// no more message
+	if (self.messagestr!="") 
+		self.messagestr = "";
 	oself = self;
 
 	if (self.spawnflags & DOOR_TOGGLE)
@@ -561,6 +567,9 @@ entity oself;
 	self.message = 0;			// door messages are for touch only
 	self.owner.message = 0;
 	self.enemy.message = 0;
+	self.messagestr="";		//SoC
+	self.owner.messagestr="";
+	self.enemy.messagestr="";
 	oself = self;
 	self = self.owner;
 	door_fire ();
@@ -602,9 +611,12 @@ void door_trigger_touch()
 
 		if (!check_puzzle_pieces(other,removepp,inversepp))
 		{
-			if (self.no_puzzle_msg && !deathmatch) 
+			if ((self.no_puzzle_msg || self.no_puzzle_str!="") && !deathmatch) 
 			{
-				temp = getstring(self.no_puzzle_msg);
+				if (self.no_puzzle_str!="")
+					temp = self.no_puzzle_str;
+				else
+					temp = getstring(self.no_puzzle_msg);
 				centerprint (other, temp);
 				door.attack_finished = time + 2;
 			}
@@ -670,9 +682,12 @@ void door_touch()
 	if (self.owner)
 		self.owner.attack_finished = time + 2;
 
-	if(self.owner.message != 0 && other.flags&FL_CLIENT && !deathmatch && self.owner != world)
+	if(self.owner!=world && (self.owner.message || self.owner.messagestr!="") && other.flags&FL_CLIENT && !deathmatch)
 	{
-		temp = getstring(self.owner.message);
+		if (self.owner.messagestr != "")			//SoC: triggers can use messagestr for raw string instead of using an index for strings.txt
+			temp = self.owner.messagestr;
+		else
+			temp = getstring(self.owner.message);
 		centerprint (other, temp);
 		sound (other, CHAN_VOICE, "misc/comm.wav", 1, ATTN_NORM);
 	}
@@ -819,6 +834,8 @@ vector	cmins, cmaxs;
 			starte.targetname = self.targetname;
 		if (self.message != 0)
 			starte.message = self.message;
+		if (self.messagestr!="")
+			starte.messagestr = self.messagestr;	//SoC
 
 		t = find (t, classname, self.classname);	
 		if (!t)
@@ -1411,6 +1428,7 @@ void fd_secret_use()
 		return;
 
 	self.message = 0;		// no more message
+	self.messagestr = "";	//SoC
 
 	SUB_UseTargets();				// fire all targets / killtargets
 
@@ -1543,9 +1561,12 @@ void secret_touch()
 
 	self.attack_finished = time + 2;
 	
-	if (self.message)
+	if (self.message || self.messagestr!="")
 	{
-		s = getstring(self.message);
+		if (self.messagestr != "")			//SoC: triggers can use messagestr for raw string instead of using an index for strings.txt
+			s = self.messagestr;
+		else
+			s = getstring(self.message);
 		centerprint (other, s);
 		sound (other, CHAN_BODY, "misc/comm.wav", 1, ATTN_NORM);
 	}

--- a/hc/entity.hc
+++ b/hc/entity.hc
@@ -728,7 +728,7 @@ void end_sys_fields;
 
 .float inactive;
 .float msg2;
-.string msg3;
+.string msg3;			//only used by raven staff
 .string nexttarget;		//For target transferral
 .float gravity;			//Gravity, duh
 //.float upside_down;	unused
@@ -789,6 +789,9 @@ entity	sight_entity;	//So monsters wake up other monsters
 .float jumpframe;		//frame monsters use while in air due to disc of repulsion or trigger_monsterjump
 .void() th_raise;		//monster revival system
 .float targetid;		//numerical id for trigger_random
+.string messagestr		//string version of message
+.string msg2str;		//string version of msg2
+.string no_puzzle_str	//string version of no_puzzle_msg
 
 //rubicon 2 / arcane dimensions ladder system
 .float onladder;

--- a/hc/subs.hc
+++ b/hc/subs.hc
@@ -449,6 +449,7 @@ string s;
 		t.think = DelayThink;
 		t.enemy = activator;
 		t.message = self.message;
+		t.messagestr = self.messagestr;		//SoC
 		t.killtarget = self.killtarget;
 		t.target = self.target;
 		t.failtarget = self.failtarget;
@@ -467,9 +468,12 @@ string s;
 //
 // print the message
 //
-	if(activator.classname == "player" && self.message != 0)
+	if(activator.flags&FL_CLIENT && (self.message || self.messagestr != ""))
 	{
-		s = getstring(self.message);
+		if (self.messagestr != "")			//SoC: triggers can use messagestr for raw string instead of using an index for strings.txt
+			s = self.messagestr;
+		else
+			s = getstring(self.message);
 		centerprint (activator, s);
 		if(!self.noise)
 			sound (activator, CHAN_VOICE, "misc/comm.wav", 1, ATTN_NORM);
@@ -517,7 +521,7 @@ string s;
 // fire targets
 //
 	self.style=0;
-	if (self.target!="")
+	if (self.target != "")
 	{
 		act = activator;
 		t = world;
@@ -623,7 +627,7 @@ void (void() thinkst) SUB_CheckRefire =
 };
 */
 
-void SUB_UseWakeTargets()
+void SUB_UseWakeTargets()	//ws: monsters use self.waketarget upon sighting player
 {
 	if (self.waketarget=="")
 		return;
@@ -641,5 +645,5 @@ void SUB_UseWakeTargets()
 
 void SUB_ResetTarget()
 {
-	self.target = self.killtarget = "";
+	self.target = "";
 }


### PR DESCRIPTION
Add .messagestr, .msg2str, and .no_puzzle_str fields. Instead of using an index to a string in strings.txt, these fields take whatever string a mapper uses in the map.