### PR TITLE
Disc of repulsion affect flying enemies

### DIFF
--- a/hc/afrit.hc
+++ b/hc/afrit.hc
@@ -20,6 +20,7 @@ float AFRIT_STAGE_SLIDE = 2;
 
 void() AfritCheckDodge;
 void() afrit_wake1;
+void() afrit_blasted;
 void(entity attacker, float damage)	afrit_pain;
 
 void afrit_raise()
@@ -246,6 +247,7 @@ void() afrit_run =
 {
 	if (self.spawnflags & AFRIT_COCOON) {
 		self.spawnflags (-) AFRIT_COCOON;
+		self.th_blasted = afrit_blasted;
 		self.th_pain = afrit_pain;
 		self.th_stand = afrit_hover1;
 		self.th_run = afrit_fly1;
@@ -347,6 +349,27 @@ void()	afrit_pain11	=[	72,	afrit_pain12	] {AfritEffects();};
 void()	afrit_pain12	=[	73,	afrit_pain13	] {};
 void()	afrit_pain13	=[	74,	afrit_pain14	] {};
 void()	afrit_pain14	=[	75,	afrit_fly1	] {AfritCheckDodge();};
+
+void afrit_blasted ()
+{
+	float result = AdvanceFrame(62, 75);
+	
+	if (self.blasted > 1) {
+		ai_backfromenemy(self.blasted);
+		self.blasted -= BLAST_DECEL;
+	}
+	
+	if (random()<0.33)
+		AfritCheckDodge();
+	if (random()<0.2)
+		AfritEffects();
+	
+	if (result == AF_END)
+		self.think = afrit_fly1;
+	else
+		self.think = afrit_blasted;
+	thinktime self : HX_FRAME_TIME;
+}
 
 void()	afrit_wake1	=[	54,	afrit_wake2	] {};
 void()	afrit_wake2	=[	55,	afrit_wake3	] {};
@@ -496,8 +519,8 @@ void() monster_afrit =
 	self.movetype = MOVETYPE_STEP;
 
 	setmodel (self, "models/afrit.mdl");
+
 	setsize (self, '-16 -16 0', '16 16 36');
-	
 	if(!self.health)
 		self.health = 75;
 	self.max_health = self.health;
@@ -528,10 +551,12 @@ void() monster_afrit =
 	self.th_missile = afrit_atk1;
 	self.th_pain = afrit_pain;
 	self.th_die = afrit_die;
+	self.th_blasted = afrit_blasted;
 	self.th_init = monster_afrit;
 	self.th_raise = afrit_raise;
 	
 	if (self.spawnflags&AFRIT_COCOON) {
+		self.th_blasted = SUB_Null;
 		if (self.spawnflags&AFRIT_DORMANT) {
 			self.th_stand = afrit_dormant;
 			self.th_pain = SUB_Null;

--- a/hc/constant.hc
+++ b/hc/constant.hc
@@ -692,3 +692,12 @@ float IMPULSE_INFO = 50;
 float IMPULSE_RESPAWN = 51;
 float IMPULSE_FADE = 52;
 float IMPULSE_BUFF = 53;
+
+//possible extra weapons
+float IT_WEAPON5					= 8;
+float IT_WEAPON6					= 16;
+float IT_WEAPON7					= 32;
+float IT_WEAPON8					= 64;
+
+//rate of decceleration for effect of disc of repulsion on fly monsters
+float BLAST_DECEL = 4;

--- a/hc/damage.hc
+++ b/hc/damage.hc
@@ -806,6 +806,11 @@ entity holdent;
 		if (skill == 3)
 			self.pain_finished = time + 5;		
 	}
+	if (inflictor.classname=="blast" && self.th_blasted)
+	{
+		self.blasted = damage*4;
+		self.th_blasted();
+	}
 
 	self = oldself;
 };

--- a/hc/disciple.hc
+++ b/hc/disciple.hc
@@ -27,9 +27,11 @@ void()	bishop_dsprite12	=[	11,	bishop_dsprite12	] {remove(self);};
 void()	bishop_float1	=[	0,	bishop_float2	] {ai_stand();};
 void()	bishop_float2	=[	1,	bishop_float3	] {ai_stand();};
 void()	bishop_float3	=[	2,	bishop_float4	] {ai_stand();};
-void()	bishop_float4	=[	3,	bishop_float5	] {ai_stand();if (random() < 0.01)
-{
-	sound (self, CHAN_VOICE, "disciple/idle.wav", 1,  ATTN_IDLE); }else if (random () > 0.01 && random() < 0.02) sound (self, CHAN_VOICE, "disciple/idle2.wav", 1,  ATTN_IDLE);};
+void()	bishop_float4	=[	3,	bishop_float5	] {ai_stand();
+if (random() < 0.01)
+	sound (self, CHAN_VOICE, "disciple/idle.wav", 1,  ATTN_IDLE);
+else if (random () > 0.01 && random() < 0.02)
+	sound (self, CHAN_VOICE, "disciple/idle2.wav", 1,  ATTN_IDLE); };
 void()	bishop_float5	=[	4,	bishop_float6	] {ai_stand();};
 void()	bishop_float6	=[	5,	bishop_float7	] {ai_stand();};
 void()	bishop_float7	=[	6,	bishop_float8	] {ai_stand();};
@@ -120,10 +122,26 @@ void(entity attacker, float damage)	bishop_pain =
 	else
 		sound (self, CHAN_VOICE, "disciple/pain2.wav", 1, ATTN_NORM);
 	ThrowGib ("models/blood.mdl", self.health);
+	
 	bishop_pain1 ();
 	self.pain_finished = time + 1.5;
-	
 };
+
+void bishop_blasted ()
+{
+	float result = AdvanceFrame(25, 35);
+	
+	if (self.blasted > 1) {
+		ai_backfromenemy(self.blasted);
+		self.blasted -= BLAST_DECEL;
+	}
+	
+	if (result == AF_END)
+		self.think = bishop_run1;
+	else
+		self.think = bishop_blasted;
+	thinktime self : HX_FRAME_TIME;
+}
 
 //===========================================================================
 void() discip_fx =
@@ -301,6 +319,7 @@ void() monster_disciple =
 	self.th_missile = bishop_atk1;
 	self.th_pain = bishop_pain;
 	self.th_die = bishop_die;
+	self.th_blasted = bishop_blasted;
 	self.th_init = monster_disciple;
 	
 	self.buff=2;

--- a/hc/entity.hc
+++ b/hc/entity.hc
@@ -785,6 +785,8 @@ entity	sight_entity;	//So monsters wake up other monsters
 .float statselection;	//indicates current selection (wraps between 0 and 3)
 .float statpoints; 		//counts stat points remaining
 .entity menu;			//player stats menu entity
+.void() th_blasted;		//flymonsters: function to run when hit by disc of repulsion to simulate effect
+.float blasted;			//flymonsters: distance to move back after being blasted
 
 //rubicon 2 / arcane dimensions ladder system
 .float onladder;

--- a/hc/reiver.hc
+++ b/hc/reiver.hc
@@ -3,7 +3,7 @@
 	Code by Whirledtsar, model by Razumen
 	
 	Custom/edited functions used:
-	ai.hc:		void ChangePitch ()
+	ai_ws.hc:		void ChangePitch ()
 	fx.hc:		void fx_light (vector org, float effect)
 	weapons.hc:	void Knockback (entity victim, entity attacker, entity inflictor, float force, float zmod)
 */
@@ -48,6 +48,7 @@ void() reiv_melee;
 void() reiv_meleedrain;
 void() reiv_mis;
 void(entity attacker, float damg) reiv_pain;
+void() reiv_blasted;
 void() reiv_run;
 void() reiv_stand;
 
@@ -117,6 +118,7 @@ void reiv_rise () [++ $001rise .. $024rise]
 		self.attack_finished = time+2;
 		self.movetype = MOVETYPE_STEP;
 		self.th_pain = reiv_pain;
+		self.th_blasted = reiv_blasted;
 		setsize (self, REIV_MINS, REIV_MAXS);
 		//self.solid = SOLID_SLIDEBOX;		//handled in reiv_check
 		self.takedamage = DAMAGE_YES;
@@ -577,6 +579,20 @@ float enemy_range;
 	thinktime self : 0;
 }
 
+void reiv_blasted () [++ $127stun .. $137stun]
+{
+	if (self.blasted > 1) {
+		ai_backfromenemy(self.blasted);
+		self.blasted -= BLAST_DECEL;
+	}
+	
+	if (self.frame == $137stun)
+		self.think = reiv_run;
+	else
+		self.think = reiv_blasted;
+	thinktime self : HX_FRAME_TIME;
+}
+
 void reiv_run () [++ $025idle .. $038idle]
 {
 	self.think = reiv_run;
@@ -696,6 +712,7 @@ void monster_reiver ()
 		self.th_stand = reiv_stand;
 		self.th_run = reiv_run;
 		self.th_pain = reiv_pain;
+		self.th_blasted = reiv_blasted;
 	}
 	
 	self.th_walk = reiv_walk;


### PR DESCRIPTION
Physics are different for flying enemies, making the disc of repulsion useless on them. New system simulates the effect to some extent by making them enter a state to recoil backwards.